### PR TITLE
Add GitHub Codespaces default configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "Default",
+    "settings": { 
+        "editor.renderWhitespace": "boundary",
+        "editor.fontSize": 16, 
+        "editor.tabSize": 2,
+        "editor.wordWrap": "off",
+        "workbench.colorTheme": "One Dark Pro",
+        "workbench.iconTheme": "material-icon-theme",
+        "terminal.integrated.fontFamily": "Cascadia Code PL",
+        "extensions.ignoreRecommendations": true,
+        "[python]": {
+            "editor.rulers": [
+                79
+            ]
+        },
+        "[javascript]": {
+            "editor.rulers": [
+                80
+            ]
+        },
+        "files.exclude": {
+            "**/__pycache__": true
+        }
+    },
+    "extensions": [
+        "zhuangtongfa.Material-theme",
+        "PKief.material-icon-theme",
+        "sleistner.vscode-fileutils",
+        "EditorConfig.EditorConfig",
+        "eamodio.gitlens"
+    ],
+    "forwardPorts": []
+}


### PR DESCRIPTION
This is what I mentioned about codespaces. Default configuration that loads every time you use it.

This is the documentation, in case you want to change it. Be sure you enable using the dotfiles repository for the configuration.

It includes a bunch of extensions and settings, these are some of those:
Gitlens
Material Icons
One Dark Pro Theme
EditorConfig

2 spaces tabsize,
Disable word wrap
Show boundary whitespaces

And more :)